### PR TITLE
Packer key removal

### DIFF
--- a/packer/aws_ubuntu.json
+++ b/packer/aws_ubuntu.json
@@ -70,7 +70,8 @@
                 "echo . .init-region >> /home/ubuntu/.bashrc",
                 "sudo mv /tmp/99-footer /etc/update-motd.d/99-footer",
                 "sudo chmod 755 /etc/update-motd.d/99-footer",
-                "sudo chown root:root /etc/update-motd.d/99-footer"
+                "sudo chown root:root /etc/update-motd.d/99-footer",
+                "sudo rm -rf /home/ubuntu/.ssh"
             ]
         }
     ]

--- a/packer/aws_ubuntu_release.json
+++ b/packer/aws_ubuntu_release.json
@@ -87,7 +87,8 @@
                 "echo . .init-region >> /home/ubuntu/.bashrc",
                 "sudo mv /tmp/99-footer /etc/update-motd.d/99-footer",
                 "sudo chmod 755 /etc/update-motd.d/99-footer",
-                "sudo chown root:root /etc/update-motd.d/99-footer"
+                "sudo chown root:root /etc/update-motd.d/99-footer",
+                "sudo rm -rf /home/ubuntu/.ssh"
             ]
         }
     ]


### PR DESCRIPTION
added commands to packer config to remove ~ubuntu/.ssh so amis can be submitted to the aws marketplace.